### PR TITLE
Fix CI on main: SwiftLint 0.65.1 line length and aria2 stderr race

### DIFF
--- a/Cotabby/App/Core/AppDelegate.swift
+++ b/Cotabby/App/Core/AppDelegate.swift
@@ -138,7 +138,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "?"
         let build = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "?"
-        CotabbyLogger.app.info("Cotabby \(version) (build \(build)) launching on macOS \(ProcessInfo.processInfo.operatingSystemVersionString)")
+        CotabbyLogger.app.info(
+            "Cotabby \(version) (build \(build)) launching on macOS \(ProcessInfo.processInfo.operatingSystemVersionString)"
+        )
         applyLaunchAtLoginDefaultIfNeeded()
         startRuntimeIfPreferredEngineRequiresIt()
         focusModel.start()

--- a/Cotabby/Services/ModelManagement/Aria2DownloadService.swift
+++ b/Cotabby/Services/ModelManagement/Aria2DownloadService.swift
@@ -109,12 +109,20 @@ nonisolated final class Aria2DownloadService: @unchecked Sendable {
             errorBuffer.append(text)
         }
 
+        // Every read from either pipe, whether a readability callback or the termination drain
+        // below, runs on this one serial queue. That is what makes the drain complete: a callback
+        // that already pulled bytes with `availableData` finishes appending them before the drain
+        // starts, and a callback that lands after the drain finds the pipe at EOF. Detaching a
+        // handler alone does not wait for an in-flight callback, so without the queue the final
+        // stderr write could still be lost on a slow machine.
+        let pipeReadQueue = DispatchQueue(label: "com.cotabby.aria2.pipe-read")
+
         outputPipe.fileHandleForReading.readabilityHandler = { handle in
-            consumeOutput(handle.availableData)
+            pipeReadQueue.sync { consumeOutput(handle.availableData) }
         }
 
         errorPipe.fileHandleForReading.readabilityHandler = { handle in
-            consumeError(handle.availableData)
+            pipeReadQueue.sync { consumeError(handle.availableData) }
         }
 
         return try await withCheckedThrowingContinuation { continuation in
@@ -122,19 +130,23 @@ nonisolated final class Aria2DownloadService: @unchecked Sendable {
                 outputPipe.fileHandleForReading.readabilityHandler = nil
                 errorPipe.fileHandleForReading.readabilityHandler = nil
 
-                // The readability handlers run on their own queue, so a process that exits right
-                // after its last write can terminate before those bytes were consumed; on a slow
-                // machine that turned "simulated aria failure" into a bare exit code. Draining to
-                // EOF here cannot block: the child's write ends closed when it exited, and the
-                // parent's copies were closed at launch.
-                consumeOutput(outputPipe.fileHandleForReading.readDataToEndOfFile())
-                consumeError(errorPipe.fileHandleForReading.readDataToEndOfFile())
+                // A process that exits right after its last write can terminate before the
+                // readability callbacks consumed those bytes; on a slow machine that turned
+                // "simulated aria failure" into a bare exit code. Drain both pipes to EOF on the
+                // read queue, then snapshot the message on the same queue so nothing appends after
+                // the snapshot. The drain cannot block: the child's write ends closed when it
+                // exited, and the parent's copies were closed at launch.
+                let errorMessage = pipeReadQueue.sync {
+                    consumeOutput(outputPipe.fileHandleForReading.readDataToEndOfFile())
+                    consumeError(errorPipe.fileHandleForReading.readDataToEndOfFile())
+                    return errorBuffer.value
+                }
 
                 continuation.resume(
                     with: Self.completionResult(
                         status: terminatedProcess.terminationStatus,
                         requestedOutcome: processState.finish(),
-                        errorMessage: errorBuffer.value,
+                        errorMessage: errorMessage,
                         targetURL: targetURL
                     )
                 )

--- a/Cotabby/Services/ModelManagement/Aria2DownloadService.swift
+++ b/Cotabby/Services/ModelManagement/Aria2DownloadService.swift
@@ -89,8 +89,9 @@ nonisolated final class Aria2DownloadService: @unchecked Sendable {
         process.standardOutput = outputPipe
         process.standardError = errorPipe
 
-        outputPipe.fileHandleForReading.readabilityHandler = { [progressHandler] handle in
-            let data = handle.availableData
+        // Shared by the readability handlers and the termination drain below, so bytes that arrive
+        // either way are parsed identically.
+        let consumeOutput: @Sendable (Data) -> Void = { [progressHandler] data in
             guard !data.isEmpty, let text = String(data: data, encoding: .utf8) else {
                 return
             }
@@ -101,19 +102,33 @@ nonisolated final class Aria2DownloadService: @unchecked Sendable {
                 }
             }
         }
-
-        errorPipe.fileHandleForReading.readabilityHandler = { handle in
-            let data = handle.availableData
+        let consumeError: @Sendable (Data) -> Void = { data in
             guard !data.isEmpty, let text = String(data: data, encoding: .utf8) else {
                 return
             }
             errorBuffer.append(text)
         }
 
+        outputPipe.fileHandleForReading.readabilityHandler = { handle in
+            consumeOutput(handle.availableData)
+        }
+
+        errorPipe.fileHandleForReading.readabilityHandler = { handle in
+            consumeError(handle.availableData)
+        }
+
         return try await withCheckedThrowingContinuation { continuation in
             process.terminationHandler = { [processState] terminatedProcess in
                 outputPipe.fileHandleForReading.readabilityHandler = nil
                 errorPipe.fileHandleForReading.readabilityHandler = nil
+
+                // The readability handlers run on their own queue, so a process that exits right
+                // after its last write can terminate before those bytes were consumed; on a slow
+                // machine that turned "simulated aria failure" into a bare exit code. Draining to
+                // EOF here cannot block: the child's write ends closed when it exited, and the
+                // parent's copies were closed at launch.
+                consumeOutput(outputPipe.fileHandleForReading.readDataToEndOfFile())
+                consumeError(errorPipe.fileHandleForReading.readDataToEndOfFile())
 
                 continuation.resume(
                     with: Self.completionResult(


### PR DESCRIPTION
## Summary

Two failures on `main` now hit every open PR, including #814, because the macos-latest image moved from SwiftLint 0.65.0 to 0.65.1. SwiftLint 0.65.1 fixed `ignores_urls` so member names that are valid top-level domains (`.app`, `.info`) no longer make a line count as a URL; that exposed the 144-character launch log line in `AppDelegate`, which 0.65.0 had silently skipped. Separately, `Aria2DownloadService` read its stderr buffer in the termination handler while the readability handler, on its own queue, could still hold the process's final write; on the slower runner the message degraded to "Process terminated with exit code 7" and `test_downloadSurfacesProcessExitAndStderr` failed. The log line is wrapped, and both pipes are now drained to EOF in the termination handler through the same parsing the handlers use.

## Validation

```
swiftlint --strict --quiet      # 0.65.0 locally; the AppDelegate line is now 124 chars, under the cap for any version
xcodebuild test -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' \
  -only-testing:CotabbyTests/Aria2DownloadServiceTests CODE_SIGNING_ALLOWED=NO -derivedDataPath build/DerivedData
# 11 tests, 0 failures
# plus test_downloadSurfacesProcessExitAndStderr with -test-iterations 40: 40/40
```

The race never reproduces locally (40/40 before the fix as well), so the CI run on this PR is the real check. Draining cannot block: the child's write ends close when it exits and the parent's copies were closed at launch.

Second commit, after the bot reviews: every pipe read, readability callbacks and the drain alike, now runs on one serial queue and the message is snapshotted on that queue, so a callback that already pulled the final bytes finishes appending them before the drain, and a late callback finds EOF. Suite 11/11 and 40/40 stress again.

## Linked issues

Unblocks #814 (its Lint and Tests checks fail on these two `main` issues, not on its own changes).

## Risk / rollout notes

- No behavior change for successful downloads; the drain only adds whatever bytes the handlers had not consumed yet, which is also where the last progress line lives.
- The Lint workflow intentionally floats with whatever SwiftLint Homebrew ships, so rule-behavior drift like this can recur; pinning a version is a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved download process completion handling to reliably capture all standard output and error messages, including final data written as the process exits.
  * Prevented missing or out-of-order process output when data arrives while the download is terminating.

* **Maintenance**
  * Reformatted an application launch log statement without changing its behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR restores CI stability by wrapping an AppDelegate launch log below SwiftLint’s line-length limit and making aria2 stdout/stderr consumption deterministic.
- Routes readability callbacks and termination-time draining through one serial queue.
- Snapshots stderr only after queued reads and the EOF drain complete.
- Resolves the previously reported in-flight callback race.
- Preserves existing successful-download and progress parsing behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; the latest synchronization change fully addresses the previously reported stderr race without introducing a new actionable defect.

The serial pipe-read queue ensures an in-flight readability callback finishes consuming and appending its bytes before termination drains to EOF and snapshots stderr. The prior finding was manually resolved without an explanatory reply, and the current implementation independently confirms that its race is fixed.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| Cotabby/App/Core/AppDelegate.swift | Wraps the launch log expression to satisfy SwiftLint line-length enforcement without changing behavior. |
| Cotabby/Services/ModelManagement/Aria2DownloadService.swift | Serializes pipe reads and snapshots stderr after the termination drain, closing the previously reported final-output race. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant P as aria2 Process
    participant H as Pipe Readability Handler
    participant Q as Serial Pipe Read Queue
    participant T as Termination Handler
    participant C as Continuation

    P->>H: stdout/stderr bytes available
    H->>Q: sync consume availableData
    Q-->>H: bytes parsed/appended
    P->>T: process terminates
    T->>T: detach readability handlers
    T->>Q: sync drain both pipes to EOF
    Q->>Q: parse remaining output
    Q->>Q: snapshot stderr
    Q-->>T: final error message
    T->>C: resume with completion result
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Serialize aria2 pipe reads with the term..."](https://github.com/fujacob/cotabby/commit/c6a7d26ff16248edfc7b180355cdee98c0de6ab1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60636022)</sub>

**Context used:**

- Knowledge Base — [Local model management](https://app.greptile.com/tabby/-/custom-context/knowledge-base/fujacob/cotabby/-/docs/model-management.md)

<!-- /greptile_comment -->