### PR TITLE
fix(focus): prime Obsidian's Electron accessibility tree so suggestions work (#791)

### DIFF
--- a/Cotabby/Support/Focus/Applications/BrowserAppDetector.swift
+++ b/Cotabby/Support/Focus/Applications/BrowserAppDetector.swift
@@ -46,6 +46,14 @@ nonisolated enum BrowserAppDetector {
     /// editor, the Copilot chat, or the integrated terminal, so no suggestions appear anywhere in the
     /// app even though screenshot-based OCR keeps working.
     ///
+    /// Obsidian (`md.obsidian`, issue #791) is the same failure in a different editor. Its
+    /// CodeMirror 6 surface is a `contenteditable` with `role="textbox"`, which Chromium exposes as
+    /// `AXTextArea` only once the web-AX tree is awake. A read-only probe of Obsidian 1.12.7
+    /// (Electron 39) showed the application element advertising `AXManualAccessibility` (settable,
+    /// value 0) while the focused window held a single bare `AXGroup`: the dormant renderer view.
+    /// With the bundle absent here nothing ever flipped that switch, so the system-wide focus query
+    /// returned nil and the tracker reported "No focused Accessibility element" on every tick.
+    ///
     /// Cursor is intentionally absent: it ships under opaque ToDesktop bundle ids
     /// (`com.todesktop.<hash>`) that change between builds, so there is no stable id to allowlist
     /// here without a broad `com.todesktop.` prefix that would also prime unrelated ToDesktop apps.
@@ -53,7 +61,8 @@ nonisolated enum BrowserAppDetector {
         "com.clickup.desktop-app",
         "com.microsoft.vscode",          // Visual Studio Code
         "com.microsoft.vscodeinsiders",  // VS Code - Insiders
-        "com.vscodium"                   // VSCodium (FOSS VS Code build)
+        "com.vscodium",                  // VSCodium (FOSS VS Code build)
+        "md.obsidian"                    // Obsidian (Electron, CodeMirror 6 editor) — #791
     ]
 
     /// Broad check: is the user typing inside any web browser? Used for prompt tone hints.

--- a/CotabbyTests/Support/Accessibility/WebContentFieldDetectorTests.swift
+++ b/CotabbyTests/Support/Accessibility/WebContentFieldDetectorTests.swift
@@ -66,6 +66,14 @@ final class WebContentFieldDetectorTests: XCTestCase {
                 vendsDOMAttributes: false
             )
         )
+        // Obsidian is an allowlisted Electron editor (#791), so its fields count as web content even
+        // before the DOM-reflection attributes arrive on the focused node.
+        XCTAssertTrue(
+            WebContentFieldDetector.isWebContentField(
+                bundleIdentifier: "md.obsidian",
+                vendsDOMAttributes: false
+            )
+        )
     }
 
     func test_nativeAppIsNotWebContent() {

--- a/CotabbyTests/Support/Focus/Applications/BrowserAppDetectorTests.swift
+++ b/CotabbyTests/Support/Focus/Applications/BrowserAppDetectorTests.swift
@@ -37,6 +37,11 @@ final class BrowserAppDetectorTests: XCTestCase {
         XCTAssertTrue(BrowserAppDetector.isElectronEditor(bundleIdentifier: "com.microsoft.VSCode"))
         XCTAssertTrue(BrowserAppDetector.isElectronEditor(bundleIdentifier: "com.microsoft.VSCodeInsiders"))
         XCTAssertTrue(BrowserAppDetector.isElectronEditor(bundleIdentifier: "com.vscodium"))
+        // Obsidian (#791): Electron 39 / CodeMirror 6. Its app element advertises
+        // AXManualAccessibility, but nothing flips it unless the bundle is allowlisted here, so the
+        // editor's web-AX tree stays dormant and no focused field ever resolves.
+        XCTAssertTrue(BrowserAppDetector.isElectronEditor(bundleIdentifier: "md.obsidian"))
+        XCTAssertTrue(BrowserAppDetector.isElectronEditor(bundleIdentifier: "MD.Obsidian"))
         // Electron, but not a text-editing surface we cover: must stay out of the priming allowlist.
         XCTAssertFalse(BrowserAppDetector.isElectronEditor(bundleIdentifier: "com.hnc.Discord"))
         XCTAssertFalse(BrowserAppDetector.isElectronEditor(bundleIdentifier: nil))
@@ -49,6 +54,8 @@ final class BrowserAppDetectorTests: XCTestCase {
             BrowserAppDetector.needsWebAccessibilityPriming(bundleIdentifier: "com.clickup.desktop-app"))
         XCTAssertTrue(
             BrowserAppDetector.needsWebAccessibilityPriming(bundleIdentifier: "com.microsoft.VSCode"))
+        XCTAssertTrue(
+            BrowserAppDetector.needsWebAccessibilityPriming(bundleIdentifier: "md.obsidian"))
         XCTAssertFalse(
             BrowserAppDetector.needsWebAccessibilityPriming(bundleIdentifier: "com.apple.Safari"))
         XCTAssertFalse(


### PR DESCRIPTION
## Summary

Obsidian (`md.obsidian`) was missing from `BrowserAppDetector.electronEditorBundleIdentifiers`, so Cotabby never set `AXManualAccessibility` on it. Electron builds its accessibility tree lazily; without that switch Obsidian's window exposes a single bare `AXGroup`, the system-wide focused-element query returns nil, and the focus tracker logs "No focused Accessibility element" on every tick. Adding the bundle id to the allowlist turns on the same priming, app-scoped focus fallback, descendant search and web-content caret handling that fixed VS Code in #671.

Evidence: a read-only AX probe of Obsidian 1.12.7 (Electron 39.8.3 / Chromium 142) shows the application element advertising `AXManualAccessibility` (settable, value 0) and `AXEnhancedUserInterface`, with the focused window holding one `AXGroup` and three buttons, i.e. the dormant renderer view. Obsidian worked in 0.3.3 (#276) and broke in 0.6.0 when the Electron allowlist gate was introduced.

## Validation

```
xcodebuild test -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' \
  -skip-testing:CotabbyTests/FoundationModelDriftEvalTests CODE_SIGNING_ALLOWED=NO \
  -derivedDataPath "$HOME/Library/Caches/myCotabby/DerivedData"
# ** TEST SUCCEEDED **  Executed 1785 tests, with 6 tests skipped and 0 failures
```

- The four new assertions (`BrowserAppDetectorTests`, `WebContentFieldDetectorTests`) failed before the one-line allowlist change and pass after it.
- `xcodebuild build` of the `Cotabby Dev` scheme: succeeded (3 pre-existing warnings, 0 errors).
- `swiftlint lint --config .swiftlint.yml --quiet` (SwiftLint 0.65.1): exit 0, no warnings on the changed files; repo-wide count unchanged versus `main` (0 → 0).
- End-to-end on macOS 26.6.2, Obsidian 1.12.7 (Electron 39.8.3): with a Debug build of this branch (`-cotabby-debug`) and Obsidian frontmost, the log shows `CHROME-PRIME enabled web accessibility for Obsidian`, then `CHROME-FOCUS-PROBE resolved via hit-test for Obsidian`, then `Focus snapshot changed: app=Obsidian capability=Supported` with `caret=derived` (and `exact`) on every resolve, i.e. the inline ghost-text path, not the popup fallback. Ghost text appears in the editor and can be accepted. On `main` the same session logs only `No focused Accessibility element` for Obsidian.

## Linked issues

Fixes #791
Refs #616 (ghost-text placement inside Obsidian is a separate geometry problem and is not addressed here)
Refs #626, #671

## Risk / rollout notes

- Behavior change is limited to `md.obsidian`: Cotabby now sets `AXManualAccessibility` on Obsidian's application element, exactly as it already does for Chromium browsers, ClickUp and VS Code. No settings, schema or pbxproj changes.
- Obsidian bundles that ship under other ids (Insider builds use the same `md.obsidian`) are covered; matching is case-insensitive and exact, so no other `md.*` app is affected.
- Placement (#616) may still route to the popup card where CodeMirror's caret geometry is only `.estimated`; that is the existing `CompletionRenderModePolicy` behaviour and is left for a follow-up.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved focus detection in Obsidian and VSCodium editor fields.
  * Obsidian editor content is now recognized as web content even when DOM metadata is unavailable.

* **Tests**
  * Added coverage for Obsidian and case-insensitive application identifiers.
  * Added verification for Obsidian’s accessibility priming behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds Obsidian to the existing Electron-editor allowlist so Cotabby primes its dormant web accessibility tree and can resolve its CodeMirror editing surface.
- Recognizes `md.obsidian` case-insensitively as a covered Electron editor.
- Applies the existing accessibility-priming and web-content detection paths to Obsidian.
- Adds focused tests for bundle detection, priming eligibility, and web-content classification.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no outstanding or newly introduced actionable issues.

The current diff narrowly extends an existing Electron recovery path to Obsidian and adds aligned tests; there have been no changes since the previous review and no repository-rule violations remain.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| Cotabby/Support/Focus/Applications/BrowserAppDetector.swift | Adds Obsidian's bundle identifier to the narrow Electron-editor accessibility-priming allowlist. |
| CotabbyTests/Support/Accessibility/WebContentFieldDetectorTests.swift | Verifies that Obsidian fields are classified as web content without DOM-reflection attributes. |
| CotabbyTests/Support/Focus/Applications/BrowserAppDetectorTests.swift | Covers Obsidian detection, case-insensitive matching, and accessibility-priming eligibility. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(focus): prime Obsidian&#39;s Electron AX..."](https://github.com/fujacob/cotabby/commit/853eef4f72b8a843e7382c1cb96eebeba46948c2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61229098)</sub>

**Context used:**

- Knowledge Base — [Accessibility, focus, and input integration](https://app.greptile.com/tabby/-/custom-context/knowledge-base/fujacob/cotabby/-/docs/accessibility-and-input.md)
- Knowledge Base — [Focus tracking and text-surface resolution](https://app.greptile.com/tabby/-/custom-context/knowledge-base/fujacob/cotabby/-/docs/focus-tracking-and-resolution.md)

<!-- /greptile_comment -->